### PR TITLE
To copy requirements.txt to docker image and install. This is an effo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.7.2-slim
-WORKDIR /app
-COPY . /app
-RUN pip install --trusted-host pypi.python.org -r requirements.txt
+WORKDIR /meshtest
+COPY ./requirements.txt /meshtest/requirements.txt
+RUN pip install --trusted-host pypi.python.org -r /meshtest/requirements.txt
+COPY . /meshtest
 ENV PYTHONPATH $(pwd)
 CMD ["python", "-m", "unittest", "discover", "MeshTest"]


### PR DESCRIPTION
…rt to avoid resolving python dependency repeatedly.